### PR TITLE
Bump org.springframework.boot to 2.5.14

### DIFF
--- a/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistServiceTestExport.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/PlaylistServiceTestExport.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.12</version>
+        <version>2.5.14</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
From https://github.com/4oo4/airsonic-advanced/commit/806ef0b3375d7ac97c1c260f42d963298f45d14e

Resolves:
- CVE-2022-22978 (org.springframework.security:spring-security-core)
- CVE-2022-22976 (org.springframework.security:spring-security-core)
- CVE-2022-22968 (org.springframework:spring-core)
- CVE-2022-22970 (org.springframework:spring-core)
- CVE-2022-22971 (org.springframework:spring-core)


